### PR TITLE
Ignore the installed (or invalid) products (bsc#941532)

### DIFF
--- a/package/yast2-migration.changes
+++ b/package/yast2-migration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Aug 14 07:37:00 UTC 2015 - lslezak@suse.cz
+
+- ignore the installed products when searching for obsolete
+  repositories (bsc#941532)
+- 3.1.4
+
+-------------------------------------------------------------------
 Thu Aug 13 13:50:14 UTC 2015 - lslezak@suse.cz
 
 - display a finish dialog at the very end, suggest rebooting the

--- a/package/yast2-migration.spec
+++ b/package/yast2-migration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-migration
-Version:        3.1.3
+Version:        3.1.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/migration/repository_checker.rb
+++ b/src/lib/migration/repository_checker.rb
@@ -37,6 +37,9 @@ module Migration
     def obsolete_product_repos
       old_repos = obsolete_available_products.map { |product| product["source"] }
 
+      # make sure the system repo or invalid values are filtered out
+      old_repos.reject! { |r| r < 0 }
+
       # remove (possible) duplicates
       old_repos.uniq!
 

--- a/src/lib/migration/repository_checker.rb
+++ b/src/lib/migration/repository_checker.rb
@@ -38,6 +38,7 @@ module Migration
       old_repos = obsolete_available_products.map { |product| product["source"] }
 
       # make sure the system repo or invalid values are filtered out
+      # (related to gh#yast/yast-registration#198)
       old_repos.reject! { |r| r < 0 }
 
       # remove (possible) duplicates


### PR DESCRIPTION
...when searching for obsolete repositories

- 3.1.4

Note: this might not be needed after fixing the broken repository synchronization (which resulted in `-1` repositories), but it's a good safety check, rather be safe than sorry...