### PR TITLE
Restore the *-Update repositories at the end of migration

### DIFF
--- a/package/yast2-migration.changes
+++ b/package/yast2-migration.changes
@@ -2,6 +2,8 @@
 Tue Sep  1 11:08:47 UTC 2015 - lslezak@suse.cz
 
 - disable "Back" at the initial dialog
+- restore (enable) the Updates repositories at the end of the
+  migration workflow (bsc#943960)
 
 -------------------------------------------------------------------
 Wed Aug 19 10:36:35 UTC 2015 - lslezak@suse.cz

--- a/package/yast2-migration.changes
+++ b/package/yast2-migration.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Sep  1 11:08:47 UTC 2015 - lslezak@suse.cz
+
+- disable "Back" at the initial dialog
+
+-------------------------------------------------------------------
 Wed Aug 19 10:36:35 UTC 2015 - lslezak@suse.cz
 
 - create the "post" snapshot after restart to avoid possible issues

--- a/package/yast2-migration.changes
+++ b/package/yast2-migration.changes
@@ -4,6 +4,7 @@ Tue Sep  1 11:08:47 UTC 2015 - lslezak@suse.cz
 - disable "Back" at the initial dialog
 - restore (enable) the Updates repositories at the end of the
   migration workflow (bsc#943960)
+- 3.1.8
 
 -------------------------------------------------------------------
 Wed Aug 19 10:36:35 UTC 2015 - lslezak@suse.cz

--- a/package/yast2-migration.spec
+++ b/package/yast2-migration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-migration
-Version:        3.1.7
+Version:        3.1.8
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-migration.spec
+++ b/package/yast2-migration.spec
@@ -40,7 +40,7 @@ Requires:	yast2-packager
 Requires:	yast2-pkg-bindings
 Requires:       yast2-ruby-bindings
 # new registration with migration support
-Requires:       yast2-registration >= 3.1.135
+Requires:       yast2-registration >= 3.1.147
 # need recent enough installation for working proposal runner
 Requires:       yast2-installation >= 3.1.146
 Requires:       yast2-update

--- a/src/desktop/migration.desktop
+++ b/src/desktop/migration.desktop
@@ -3,7 +3,7 @@ Type=Application
 Categories=Settings;System;Qt;X-SuSE-YaST;X-SuSE-YaST-System;
 
 X-KDE-ModuleType=Library
-X-SuSE-YaST-Call=bootloader
+X-SuSE-YaST-Call=migration
 
 X-SuSE-YaST-Group=Software
 X-SuSE-YaST-Argument=

--- a/src/lib/migration/main_workflow.rb
+++ b/src/lib/migration/main_workflow.rb
@@ -69,7 +69,7 @@ module Migration
       "ws_start"             => "start",
       "start"                => {
         start:   "create_pre_snapshot",
-        restart: "create_post_snapshot"
+        restart: "migration_finish"
       },
       "create_pre_snapshot"  => {
         next: "create_backup"
@@ -97,6 +97,10 @@ module Migration
       },
       # note: the steps after the YaST restart use the new code from
       # the updated (migrated) yast2-migration package!!
+      "migration_finish"     => {
+        abort: :abort,
+        next:  "create_post_snapshot"
+      },
       "create_post_snapshot" => {
         next: "finish_dialog"
       },
@@ -118,6 +122,7 @@ module Migration
         "restart_yast"         => ->() { restart_yast },
         # note: the steps after the YaST restart use the new code from
         # the updated (migrated) yast2-migration package!!
+        "migration_finish"     => ->() { migration_finish },
         "create_post_snapshot" => ->() { create_post_snapshot },
         "finish_dialog"        => ->() { finish_dialog }
       }
@@ -173,6 +178,10 @@ module Migration
       end
 
       :next
+    end
+
+    def migration_finish
+      Yast::WFM.CallFunction("migration_finish")
     end
 
     # check whether snapper is configured

--- a/src/lib/migration/main_workflow.rb
+++ b/src/lib/migration/main_workflow.rb
@@ -157,8 +157,11 @@ module Migration
     end
 
     def perform_update
+      # this client is located in the yast2-installation package
       Yast::WFM.CallFunction("inst_prepareprogress")
+      # this client is located in the yast2-packager package
       Yast::WFM.CallFunction("inst_kickoff")
+      # this client is located in the yast2-packager package
       Yast::WFM.CallFunction("inst_rpmcopy")
 
       :next
@@ -181,6 +184,7 @@ module Migration
     end
 
     def migration_finish
+      # this client is located in the yast2-registration package
       Yast::WFM.CallFunction("migration_finish")
     end
 

--- a/src/lib/migration/main_workflow.rb
+++ b/src/lib/migration/main_workflow.rb
@@ -144,7 +144,7 @@ module Migration
     end
 
     def repositories
-      Yast::WFM.CallFunction("migration_repos")
+      Yast::WFM.CallFunction("migration_repos", [{ "enable_back" => false }])
     end
 
     def proposals

--- a/src/lib/migration/proposal_client.rb
+++ b/src/lib/migration/proposal_client.rb
@@ -178,6 +178,9 @@ module Migration
 
       log.info "Disabling repository #{repo}"
       Pkg.SourceSetEnabled(repo, false)
+
+      # disable the old repo permanently to not possibly mess the system later
+      Pkg.SourceSaveAll
     end
 
     # proposal help text

--- a/src/lib/migration/restarter.rb
+++ b/src/lib/migration/restarter.rb
@@ -26,6 +26,7 @@ require "yaml"
 module Migration
   # this class handles restarting the YaST module during online migration
   class Restarter
+    include Yast::Logger
     include Singleton
 
     Yast.import "Installation"
@@ -46,25 +47,36 @@ module Migration
       @restarted = File.exist?(MIGRATION_RESTART)
       @data = YAML.load_file(MIGRATION_RESTART) if restarted
 
+      log.info "Initialized restart status: #{inspect}"
+
       clear_restart
     end
 
     # set the restart flag
+    # @param [Object] data optional data saved in the restart file, the data will
+    # be available after the restart
     def restart_yast(data = nil)
+      log.info "Creating the restart file"
       File.write(RESTART_FILE, "")
+      log.info "Storing restart data: #{data.inspect}"
       File.write(MIGRATION_RESTART, data.to_yaml)
     end
 
+    # create the reboot file, yast will reboot the machine after finishing the module
     def reboot
+      log.info "Creating the reboot file"
       File.write(REBOOT_FILE, "")
     end
 
+    # clear the reboot file
     def clear_reboot
+      log.info "Clearing the reboot file"
       File.unlink(REBOOT_FILE) if File.exist?(REBOOT_FILE)
     end
 
     # clear the set restart flags
     def clear_restart
+      log.info "Clearing the restart file"
       File.unlink(RESTART_FILE) if File.exist?(RESTART_FILE)
       File.unlink(MIGRATION_RESTART) if File.exist?(MIGRATION_RESTART)
     end

--- a/test/main_workflow_test.rb
+++ b/test/main_workflow_test.rb
@@ -39,6 +39,7 @@ describe Migration::MainWorkflow do
       mock_client("inst_prepareprogress", :next)
       mock_client("inst_kickoff", :next)
       mock_client("inst_rpmcopy", :next)
+      mock_client("migration_finish", :next)
 
       allow(Yast::Update).to receive(:clean_backup)
       allow(Yast::Update).to receive(:create_backup)

--- a/test/main_workflow_test.rb
+++ b/test/main_workflow_test.rb
@@ -34,7 +34,7 @@ describe Migration::MainWorkflow do
     end
 
     before do
-      mock_client("migration_repos", :next)
+      mock_client(["migration_repos", [{ "enable_back" => false }]], :next)
       mock_client(["migration_proposals", [{ "hide_export" => true }]], :next)
       mock_client("inst_prepareprogress", :next)
       mock_client("inst_kickoff", :next)


### PR DESCRIPTION
This is the second part of the fix related to https://github.com/yast/yast-registration/pull/208.