### PR TITLE
Rollback registration when online migration is aborted

### DIFF
--- a/package/yast2-migration.changes
+++ b/package/yast2-migration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Sep 22 17:18:52 UTC 2015 - lslezak@suse.cz
+
+- rollback registration when migration is aborted after registering
+  the migration products (FATE#315161)
+
+-------------------------------------------------------------------
 Wed Sep 16 12:18:15 UTC 2015 - lslezak@suse.cz
 
 - install package management patches at the beginning to ensure

--- a/package/yast2-migration.changes
+++ b/package/yast2-migration.changes
@@ -3,6 +3,7 @@ Tue Sep 22 17:18:52 UTC 2015 - lslezak@suse.cz
 
 - rollback registration when migration is aborted after registering
   the migration products (FATE#315161)
+- 3.1.10
 
 -------------------------------------------------------------------
 Wed Sep 16 12:18:15 UTC 2015 - lslezak@suse.cz

--- a/package/yast2-migration.spec
+++ b/package/yast2-migration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-migration
-Version:        3.1.9
+Version:        3.1.10
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-migration.spec
+++ b/package/yast2-migration.spec
@@ -39,8 +39,8 @@ Requires:	yast2 >= 3.1.130
 Requires:	yast2-packager
 Requires:	yast2-pkg-bindings
 Requires:       yast2-ruby-bindings
-# new registration with migration support
-Requires:       yast2-registration >= 3.1.147
+# new rollback client
+Requires:       yast2-registration >= 3.1.153
 # need recent enough installation for working proposal runner
 Requires:       yast2-installation >= 3.1.146
 Requires:       yast2-update


### PR DESCRIPTION
- Calls the new client added in https://github.com/yast/yast-registration/pull/214
- Aborts without rollback when aborted early in the workflow (rollback is need after the migration products are registered, until that point the original products are still registered).