### PR TITLE
Fixed abort during package installation

### DIFF
--- a/package/yast2-migration.changes
+++ b/package/yast2-migration.changes
@@ -3,6 +3,7 @@ Thu Sep 24 19:12:38 UTC 2015 - lslezak@suse.cz
 
 - do not display the "success" dialog when the package installation
   is aborted
+- 3.1.11
 
 -------------------------------------------------------------------
 Tue Sep 22 17:18:52 UTC 2015 - lslezak@suse.cz

--- a/package/yast2-migration.changes
+++ b/package/yast2-migration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Sep 24 19:12:38 UTC 2015 - lslezak@suse.cz
+
+- do not display the "success" dialog when the package installation
+  is aborted
+
+-------------------------------------------------------------------
 Tue Sep 22 17:18:52 UTC 2015 - lslezak@suse.cz
 
 - rollback registration when migration is aborted after registering

--- a/package/yast2-migration.changes
+++ b/package/yast2-migration.changes
@@ -2,7 +2,7 @@
 Thu Sep 24 19:12:38 UTC 2015 - lslezak@suse.cz
 
 - do not display the "success" dialog when the package installation
-  is aborted
+  is aborted (bsc#947416)
 - 3.1.11
 
 -------------------------------------------------------------------

--- a/package/yast2-migration.spec
+++ b/package/yast2-migration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-migration
-Version:        3.1.10
+Version:        3.1.11
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/migration/main_workflow.rb
+++ b/src/lib/migration/main_workflow.rb
@@ -200,9 +200,9 @@ module Migration
       # this client is located in the yast2-packager package
       Yast::WFM.CallFunction("inst_kickoff")
       # this client is located in the yast2-packager package
-      Yast::WFM.CallFunction("inst_rpmcopy")
-
-      :next
+      ret = Yast::WFM.CallFunction("inst_rpmcopy")
+      log.info "inst_rpmcopy result: #{ret.inspect}"
+      ret
     end
 
     def create_pre_snapshot

--- a/test/main_workflow_test.rb
+++ b/test/main_workflow_test.rb
@@ -81,6 +81,13 @@ describe Migration::MainWorkflow do
       expect(::Migration::MainWorkflow.run).to eq :abort
     end
 
+    it "aborts without rollback when the package installation is aborted" do
+      mock_client("inst_rpmcopy", :abort)
+      expect(Yast::WFM).to_not receive(:CallFunction).with("registration_sync")
+
+      expect(::Migration::MainWorkflow.run).to eq :abort
+    end
+
     it "rolls back registration when the migration selection abort returns rollback request" do
       mock_client(["migration_repos", [{ "enable_back" => false }]], :rollback)
       expect(Yast::WFM).to receive(:CallFunction).with("registration_sync")


### PR DESCRIPTION
Evaluate the `rpm_copy` client return value.

https://bugzilla.suse.com/show_bug.cgi?id=947416