### PR TITLE
Do not use "return" for returning the client result value (bsc#949484)

### DIFF
--- a/package/yast2-migration.changes
+++ b/package/yast2-migration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Oct  8 13:26:01 UTC 2015 - lslezak@suse.cz
+
+- fixed crash in the migration proposal (do not use "return"
+  for returning the client result value) (bsc#949484)
+
+-------------------------------------------------------------------
 Tue Oct  6 06:58:08 UTC 2015 - lslezak@suse.cz
 
 - display a hint to manually rollback the system when migration

--- a/package/yast2-migration.changes
+++ b/package/yast2-migration.changes
@@ -3,6 +3,7 @@ Thu Oct  8 13:26:01 UTC 2015 - lslezak@suse.cz
 
 - fixed crash in the migration proposal (do not use "return"
   for returning the client result value) (bsc#949484)
+- 3.1.13
 
 -------------------------------------------------------------------
 Tue Oct  6 06:58:08 UTC 2015 - lslezak@suse.cz

--- a/package/yast2-migration.spec
+++ b/package/yast2-migration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-migration
-Version:        3.1.12
+Version:        3.1.13
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/migration_proposals.rb
+++ b/src/clients/migration_proposals.rb
@@ -32,4 +32,4 @@ ensure
   Yast::Wizard.CloseDialog
 end
 
-return ret
+ret


### PR DESCRIPTION
I fixed `possibly useless use of a variable in void context` Ruby warning (https://travis-ci.org/yast/yast-migration/builds/84302232#L595), but with `return` it fails with `unexpected return` error at runtime.

And it turned out that the warning is printed only in Travis, locally it's OK (probably because Travis uses a bit older Ruby version).

Lesson learned: Do try fixing (bogus) warnings... :grimacing: