### PR TITLE
Fix reboot after migration

### DIFF
--- a/package/yast2-migration.changes
+++ b/package/yast2-migration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Oct  7 10:30:08 UTC 2016 - igonzalezsosa@suse.com
+
+- fixed "reboot" button after migration is finished
+- 3.1.0.13
+
+-------------------------------------------------------------------
 Thu Oct  8 13:26:01 UTC 2015 - lslezak@suse.cz
 
 - fixed crash in the migration proposal (do not use "return"

--- a/package/yast2-migration.changes
+++ b/package/yast2-migration.changes
@@ -2,6 +2,8 @@
 Fri Oct  7 10:30:08 UTC 2016 - igonzalezsosa@suse.com
 
 - fixed "reboot" button after migration is finished
+  (require yast2 >= 3.1.108.7 which provides the reboot
+  functionality)
 - 3.1.0.13
 
 -------------------------------------------------------------------

--- a/package/yast2-migration.spec
+++ b/package/yast2-migration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-migration
-Version:        3.1.0.12
+Version:        3.1.0.13
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -26,8 +26,8 @@ Source0:        %{name}-%{version}.tar.bz2
 Group:	        System/YaST
 License:        GPL-2.0
 Url:            http://github.com/yast/yast-migration
-BuildRequires:	yast2-buildtools
-BuildRequires:	yast2
+BuildRequires:  yast2-buildtools
+BuildRequires:  yast2
 BuildRequires:  rubygem(rspec)
 BuildRequires:  rubygem(yast-rake)
 BuildRequires:  yast2-packager
@@ -35,9 +35,9 @@ BuildRequires:  yast2-ruby-bindings
 BuildRequires:  yast2-installation
 BuildRequires:  yast2-update
 # needed in build for testing
-Requires:	yast2
-Requires:	yast2-packager
-Requires:	yast2-pkg-bindings
+Requires:       yast2 >= 3.1.108.7
+Requires:       yast2-packager
+Requires:       yast2-pkg-bindings
 Requires:       yast2-ruby-bindings
 # new rollback client
 Requires:       yast2-registration >= 3.1.129.8

--- a/package/yast2-migration.spec
+++ b/package/yast2-migration.spec
@@ -35,6 +35,7 @@ BuildRequires:  yast2-ruby-bindings
 BuildRequires:  yast2-installation
 BuildRequires:  yast2-update
 # needed in build for testing
+# yast2 3.1.108.7 handles the reboot flag
 Requires:       yast2 >= 3.1.108.7
 Requires:       yast2-packager
 Requires:       yast2-pkg-bindings

--- a/src/lib/installation/proposal_client.rb
+++ b/src/lib/installation/proposal_client.rb
@@ -95,7 +95,7 @@ module Installation
       end
     end
 
-    protected
+  protected
 
     # Abstract method to create proposal suggestion for installation
     #

--- a/src/lib/installation/proposal_runner.rb
+++ b/src/lib/installation/proposal_runner.rb
@@ -114,7 +114,7 @@ module Installation
       input_loop
     end
 
-    private
+  private
 
     # Shows dialog to user to confirm update and return user response.
     # Returns 'true' if the user confirms, 'false' otherwise.
@@ -277,10 +277,10 @@ module Installation
 
     def pre_continue_handling
       @skip = if Yast::UI.WidgetExists(Id(:skip))
-                Yast::UI.QueryWidget(Id(:skip), :Value)
-              else
-                true
-              end
+        Yast::UI.QueryWidget(Id(:skip), :Value)
+      else
+        true
+      end
       skip_blocker = Yast::UI.WidgetExists(Id(:skip)) && @skip
       if @have_blocker && !skip_blocker
         # error message is a popup
@@ -807,13 +807,13 @@ module Installation
     def html_header(submod)
       title = @store.title_for(submod)
       heading = if title.include?("<a")
-                  title
-                else
-                  Yast::HTML.Link(
-                    title,
-                    @store.id_for(submod)
-                  )
-                end
+        title
+      else
+        Yast::HTML.Link(
+          title,
+          @store.id_for(submod)
+        )
+      end
 
       Yast::HTML.Heading(heading)
     end

--- a/src/lib/installation/proposal_store.rb
+++ b/src/lib/installation/proposal_store.rb
@@ -261,7 +261,7 @@ module Installation
       matching_client.first
     end
 
-    private
+  private
 
     # Evaluates the given description map, and handles all the events
     # by returning whether to continue in the current proposal loop

--- a/src/lib/migration/finish_dialog.rb
+++ b/src/lib/migration/finish_dialog.rb
@@ -77,7 +77,7 @@ module Migration
       end
     end
 
-    private
+  private
 
     def help
       # TRANSLATORS: a short help text (the details are directly in the dialog)

--- a/src/lib/migration/main_workflow.rb
+++ b/src/lib/migration/main_workflow.rb
@@ -64,7 +64,7 @@ module Migration
       end
     end
 
-    private
+  private
 
     # remeber the "pre" snapshot id (needed for the "post" snapshot)
     attr_accessor :pre_snapshot
@@ -88,7 +88,7 @@ module Migration
         next:    "repositories"
       },
       "restart_after_update"    => {
-        restart:  :restart
+        restart: :restart
       },
       "repositories"            => {
         abort:    :abort,
@@ -108,7 +108,7 @@ module Migration
         next:  "restart_after_migration"
       },
       "restart_after_migration" => {
-        restart:  :restart
+        restart: :restart
       },
       # note: the steps after the YaST restart use the new code from
       # the updated (migrated) yast2-migration package!!

--- a/src/lib/migration/patches.rb
+++ b/src/lib/migration/patches.rb
@@ -83,7 +83,7 @@ module Migration
       end
     end
 
-    private
+  private
 
     # preselect the available patches
     def preselect

--- a/src/lib/migration/proposal_client.rb
+++ b/src/lib/migration/proposal_client.rb
@@ -87,7 +87,7 @@ module Migration
       }
     end
 
-    private
+  private
 
     # check the current products for possible issues, add product warnings
     # to the proposal summary

--- a/src/lib/migration/proposal_store.rb
+++ b/src/lib/migration/proposal_store.rb
@@ -57,7 +57,7 @@ module Migration
       MODULES_ORDER
     end
 
-    private
+  private
 
     def global_help
       _(

--- a/src/lib/migration/repository_checker.rb
+++ b/src/lib/migration/repository_checker.rb
@@ -48,7 +48,7 @@ module Migration
       old_repos
     end
 
-    private
+  private
 
     attr_accessor :products
 


### PR DESCRIPTION
This patch should fix [bsc#1000203](https://bugzilla.suse.com/show_bug.cgi?id=1000203). Although the best approach is to update your system before performing the migration, this change makes sure that `yast2-migration` depends on a proper version of `yast2` package. Take into account that `yast2-migration` was released as an update, so to use it you'll need to install it explicitly.

`yast2 3.1.108.7` includes [handling the reboot flag](https://github.com/yast/yast-yast2/pull/392).