### PR TITLE
Build fix

### DIFF
--- a/package/yast2-migration.changes
+++ b/package/yast2-migration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov 29 09:15:35 UTC 2018 - lslezak@suse.cz
+
+- Build fix, update unit tests related to the icon handling
+  (boo#1109310)
+- 4.1.1
+
+-------------------------------------------------------------------
 Sun Nov 25 18:07:13 UTC 2018 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Provide icon with module (boo#1109310)

--- a/package/yast2-migration.spec
+++ b/package/yast2-migration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-migration
-Version:        4.1.0
+Version:        4.1.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/test/main_workflow_test.rb
+++ b/test/main_workflow_test.rb
@@ -105,8 +105,8 @@ describe Migration::MainWorkflow do
 
     it "creates a pre snapshot before starting the migration" do
       expect(Yast::SCR).to receive(:Execute).with(bash_path, /snapper create .*--type=pre/)
-        .and_return(snapshot_created).ordered
-      mock_client("inst_rpmcopy", :next).ordered
+        .and_return(snapshot_created)
+      mock_client("inst_rpmcopy", :next)
 
       expect_any_instance_of(Migration::Restarter).to receive(:restart_yast)
         .with(pre_snapshot: 146, step: :restart_after_migration)

--- a/test/proposal_store_test.rb
+++ b/test/proposal_store_test.rb
@@ -72,12 +72,6 @@ module Yast
       end
     end
 
-    describe ".icon" do
-      it "returns 'yast-software'" do
-        expect(subject.icon).to eq "yast-software"
-      end
-    end
-
     describe ".tabs?" do
       it "returns false" do
         expect(subject.tabs?).to eq false

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,9 +29,9 @@ if ENV["COVERAGE"]
     add_filter "/test/"
   end
 
-  # for coverage we need to load all ruby files
+  # track all ruby files under src
   src_location = File.expand_path("../../src", __FILE__)
-  Dir["#{src_location}/{module,lib}/**/*.rb"].each { |f| require_relative f }
+  SimpleCov.track_files("#{src_location}/**/*.rb")
 
   # use coveralls for on-line code coverage reporting at Travis CI
   if ENV["TRAVIS"]


### PR DESCRIPTION
- The `icon` method has been removed from the parent class, remove the test as well
- Fixed an RSpec warning, make the check less strict:
```
WARNING: `allow(...).to receive(..).ordered` is not supported and will have no effect
```
- Fixed evaluating the code coverage, it did not count the `src/clients/*` files so the reported coverage was a bit higher than in reality. So the coverage drop is actually expected, we are no longer cheating here. :stuck_out_tongue_closed_eyes: 