### PR TITLE
Workarounds for the openSUSE => SLES migration

### DIFF
--- a/package/yast2-migration.changes
+++ b/package/yast2-migration.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Thu May 30 14:08:16 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixes for the openSUSE Leap => SLES migration (jsc#SLE-7006)
+  - Enable the openSUSE => SUSE vendor change
+  - Disable all other repositories (esp. the default OSS and
+    non-OSS repositories) which could collide with the new SLES
+    repositories
+- 4.1.2
+
+-------------------------------------------------------------------
 Thu Nov 29 09:15:35 UTC 2018 - lslezak@suse.cz
 
 - Build fix, update unit tests related to the icon handling

--- a/package/yast2-migration.spec
+++ b/package/yast2-migration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-migration
-Version:        4.1.1
+Version:        4.1.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
- Fixes for the openSUSE Leap => SLES migration ([jsc#SLE-7006](https://jira.suse.com/browse/SLE-7006))
- When migrating from openSUSE Leap to SLES:
  - We need to enable a vendor change via a zypp config file 
  - We need to disable all other repositories (esp. the old OSS and non-OSS online repositories) and use only the repositories from SCC