### PR TITLE
 Use snapper machine-readable output

### DIFF
--- a/package/yast2-migration.changes
+++ b/package/yast2-migration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Oct 28 09:54:49 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Use new snapper machine-readable output to check whether snapper
+  is configured (related to bsc#1149322).
+- 4.2.3
+
+-------------------------------------------------------------------
 Thu Aug 22 16:41:25 CEST 2019 - schubi@suse.de
 
 - Using rb_default_ruby_abi tag in the spec file in order to

--- a/package/yast2-migration.spec
+++ b/package/yast2-migration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-migration
-Version:        4.2.2
+Version:        4.2.3
 Release:        0
 Summary:        YaST2 - Online migration
 Group:          System/YaST

--- a/package/yast2-migration.spec
+++ b/package/yast2-migration.spec
@@ -47,6 +47,9 @@ Requires:       yast2-registration >= 3.1.153
 Requires:       yast2-installation >= 3.1.146
 Requires:       yast2-update
 
+# Older snapper does not provide machine-readable output
+Conflicts:      snapper < 0.8.6
+
 Supplements:    yast2-registration
 
 BuildArch: noarch

--- a/src/lib/migration/main_workflow.rb
+++ b/src/lib/migration/main_workflow.rb
@@ -41,8 +41,8 @@ module Migration
     include Yast::Logger
     include Yast::I18n
 
-    FIND_CONFIG_CMD = "/usr/bin/snapper --no-dbus list-configs | " \
-      "grep \"^root \" >/dev/null".freeze
+    FIND_CONFIG_CMD = "/usr/bin/snapper --no-dbus --csvout list-configs " \
+    "--columns config,subvolume | grep \"^root,\" >/dev/null".freeze
 
     CREATE_SNAPSHOT_CMD = "/usr/bin/snapper create --type=%{snapshot_type} " \
       "--cleanup-algorithm=number --print-number --userdata important=yes " \

--- a/test/main_workflow_test.rb
+++ b/test/main_workflow_test.rb
@@ -45,8 +45,8 @@ describe Migration::MainWorkflow do
       allow(Yast::Update).to receive(:clean_backup)
       allow(Yast::Update).to receive(:create_backup)
 
-      allow(Yast::SCR).to receive(:Execute).with(bash_path, /snapper .*list-configs/)
-        .and_return(cmd_success)
+      allow(Yast::SCR).to receive(:Execute)
+        .with(bash_path, Migration::MainWorkflow::FIND_CONFIG_CMD).and_return(cmd_success)
       allow(Yast::SCR).to receive(:Execute).with(bash_path, /snapper create/).and_return(cmd_fail)
       # simulate snapper failure (to have a better code coverage)
       allow(Yast::Report).to receive(:Error).with(/Failed to create a filesystem snapshot/)


### PR DESCRIPTION
## Problem

*Snapper* cli command is directly used to check whether *snapper* is configured. Till now, *snapper* commands only generated a human-readable output. That output might change when some new information is displayed. And such changes might ruin scripts relying on the *snapper* cli output.

But now, *snapper* is also offering a machine-readable output that should be used by scripts. 

* Part of https://trello.com/c/YAhIvrHz/417-5-optional-non-default-machine-readable-output-from-snapper.

* Requires https://github.com/openSUSE/snapper/pull/494

## Solution

*snapper* calls are adapted to use machine-readable output (*CSV* output format in this case).

## Tests

* Unit tests have been adapted.
