### PR TITLE
drop Pkg.ResolvableProperties

### DIFF
--- a/package/yast2-migration.changes
+++ b/package/yast2-migration.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Nov 19 12:00:26 CET 2019 - schubi@suse.de
+
+- Using Y2Packager::Resolvable.any? and Y2Packager::Resolvable.find
+  in order to decrease the required memory (bsc#1132650,
+  bsc#1140037).
+- 4.2.4
+
+-------------------------------------------------------------------
 Mon Oct 28 09:54:49 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Use new snapper machine-readable output to check whether snapper

--- a/package/yast2-migration.spec
+++ b/package/yast2-migration.spec
@@ -30,8 +30,7 @@ BuildRequires:  yast2-buildtools >= 4.2.2
 BuildRequires:  yast2 >= 3.1.130
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:yast-rake)
-# product_update_summary, product_update_warning
-BuildRequires:  yast2-packager >=4.2.33
+BuildRequires:  yast2-packager
 BuildRequires:  yast2-ruby-bindings
 # needed in build for testing
 BuildRequires:  yast2-installation >= 3.1.137

--- a/package/yast2-migration.spec
+++ b/package/yast2-migration.spec
@@ -39,7 +39,7 @@ BuildRequires:  update-desktop-files
 
 Requires:       yast2 >= 3.1.130
 # product_update_summary, product_update_warning
-Requires:       yast2-packager >=4.2.33
+Requires:       yast2-packager >= 4.2.33
 Requires:       yast2-pkg-bindings
 Requires:       yast2-ruby-bindings
 # new rollback client

--- a/package/yast2-migration.spec
+++ b/package/yast2-migration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-migration
-Version:        4.2.3
+Version:        4.2.4
 Release:        0
 Summary:        YaST2 - Online migration
 Group:          System/YaST
@@ -30,7 +30,8 @@ BuildRequires:  yast2-buildtools >= 4.2.2
 BuildRequires:  yast2 >= 3.1.130
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:yast-rake)
-BuildRequires:  yast2-packager
+# product_update_summary, product_update_warning
+BuildRequires:  yast2-packager >=4.2.33
 BuildRequires:  yast2-ruby-bindings
 # needed in build for testing
 BuildRequires:  yast2-installation >= 3.1.137
@@ -38,7 +39,8 @@ BuildRequires:  yast2-update
 BuildRequires:  update-desktop-files
 
 Requires:       yast2 >= 3.1.130
-Requires:       yast2-packager
+# product_update_summary, product_update_warning
+Requires:       yast2-packager >=4.2.33
 Requires:       yast2-pkg-bindings
 Requires:       yast2-ruby-bindings
 # new rollback client

--- a/src/lib/migration/proposal_client.rb
+++ b/src/lib/migration/proposal_client.rb
@@ -15,6 +15,7 @@
 
 require "installation/proposal_client"
 require "migration/repository_checker"
+require "y2packager/resolvable"
 
 module Migration
   # The proposal client for online migration
@@ -45,7 +46,7 @@ module Migration
       # recalculate the disk space usage data
       SpaceCalculation.GetPartitionInfo
 
-      products = Pkg.ResolvableProperties("", :product, "")
+      products = Y2Packager::Resolvable.find(kind: :product)
 
       ret = {
         "preformatted_proposal" => product_summary(products),
@@ -92,7 +93,7 @@ module Migration
     # check the current products for possible issues, add product warnings
     # to the proposal summary
     # @param [Hash] proposal the proposal summary (the value is modified)
-    # @param [Array<Hash>] products list of the current products (from libzypp)
+    # @param [Array<Y2Packager::Resolvable>] products list of the current products
     def add_warnings(proposal, products)
       package_warnings = Packages.product_update_warning(products)
       repo_warnings = check_repositories(products)
@@ -112,7 +113,7 @@ module Migration
     end
 
     # create a product summary for migration proposal
-    # @param [Array<Hash>] products the current libzypp products
+    # @param [Array<Y2Packager::Resolvable>] products the current libzypp products
     # @return [String] product summary text (RichText)
     def product_summary(products)
       summary_text = Packages.product_update_summary(products).map do |item|
@@ -123,7 +124,7 @@ module Migration
     end
 
     # check for obsolete repositories
-    # @param [Array<Hash>] products the current libzypp products
+    # @param [Array<Y2Packager::Resolvable>] products the current libzypp products
     # @return [Hash] warning for the proposal summary, an empty Hash is returned
     #   if everything is OK
     def check_repositories(products)

--- a/src/lib/migration/repository_checker.rb
+++ b/src/lib/migration/repository_checker.rb
@@ -19,6 +19,7 @@
 # ------------------------------------------------------------------------------
 
 require "yast"
+require "y2packager/resolvable"
 
 module Migration
   # Check for possible repository issues in the libzypp products

--- a/src/lib/migration/repository_checker.rb
+++ b/src/lib/migration/repository_checker.rb
@@ -87,6 +87,7 @@ module Migration
       # use Gem::Version internally for a proper version string comparison
       # TODO: check also "provides" to handle product renames (should not happen
       # in SP migration, but anyway...)
+      # TODO: use Pkg.CompareVersions()
       old_product.name == new_product.name &&
         (Gem::Version.new(old_product.version_version) <
           Gem::Version.new(new_product.version_version))

--- a/src/lib/migration/repository_checker.rb
+++ b/src/lib/migration/repository_checker.rb
@@ -26,7 +26,7 @@ module Migration
     include Yast::Logger
 
     # constructor
-    # @param [Array<Hash>] products list of products from pkg-bindings
+    # @param [Array<Y2Packager::Resolvable>] products list of products
     def initialize(products)
       @products = products
     end
@@ -35,7 +35,7 @@ module Migration
     # (an upgrade is available for them)
     # return [Array<Fixnum>] repositories providing obsolete products
     def obsolete_product_repos
-      old_repos = obsolete_available_products.map { |product| product["source"] }
+      old_repos = obsolete_available_products.map(&:source)
 
       # make sure the system repo or invalid values are filtered out
       # (related to gh#yast/yast-registration#198)
@@ -53,7 +53,7 @@ module Migration
     attr_accessor :products
 
     # get the available obsolete products
-    # @return [Array<Hash>] obsolete products
+    # @return [Array<Y2Packager::Resolvable>] obsolete products
     def obsolete_available_products
       obsolete_products = []
 
@@ -73,9 +73,9 @@ module Migration
 
     # select the products with the specified status
     # @param [Symbol] status required status of the products
-    # @return [Array<Hash>] list of libzypp products
+    # @return [Array<Y2Packager::Resolvable>] list of libzypp products
     def select_products(status)
-      products.select { |product| product["status"] == status }
+      products.select { |product| product.status == status }
     end
 
     # Does a product upgrade another product?
@@ -86,9 +86,9 @@ module Migration
       # use Gem::Version internally for a proper version string comparison
       # TODO: check also "provides" to handle product renames (should not happen
       # in SP migration, but anyway...)
-      old_product["name"] == new_product["name"] &&
-        (Gem::Version.new(old_product["version_version"]) <
-          Gem::Version.new(new_product["version_version"]))
+      old_product.name == new_product.name &&
+        (Gem::Version.new(old_product.version_version) <
+          Gem::Version.new(new_product.version_version))
     end
   end
 end

--- a/test/data/sles12_migration_products.yml
+++ b/test/data/sles12_migration_products.yml
@@ -1,5 +1,6 @@
 ---
 - arch: x86_64
+  kind: :product
   category: base
   description: |-
     SUSE Linux Enterprise offers a comprehensive
@@ -42,6 +43,7 @@
   version_version: '12'
 - arch: x86_64
   category: addon
+  kind: :product
   description: |-
     SUSE Linux Enterprise offers a comprehensive
             suite of products built on a single code base.
@@ -83,6 +85,7 @@
   version_version: '12.1'
 - arch: x86_64
   category: addon
+  kind: :product
   description: |-
     SUSE Linux Enterprise offers a comprehensive
             suite of products built on a single code base.

--- a/test/migration_proposal_client_test.rb
+++ b/test/migration_proposal_client_test.rb
@@ -47,10 +47,11 @@ describe Migration::ProposalClient do
 
   describe "#make_proposal" do
     let(:msg) { "Product <b>Foo</b> will be installed" }
-    let(:products) { load_yaml_data("sles12_migration_products.yml").map do |p|
-      Y2Packager::Resolvable.new(p)
+    let(:products) do
+      load_yaml_data("sles12_migration_products.yml").map do |p|
+        Y2Packager::Resolvable.new(p)
+      end
     end
-    }
 
     before do
       expect(Yast::Pkg).to receive(:PkgSolve)
@@ -76,8 +77,9 @@ describe Migration::ProposalClient do
     it "returns a warning when an obsoleted repository is present" do
       warning_string = "warning string"
       expect(Yast::Packages).to receive(:product_update_warning).and_return(
-                                  "warning_level" => :warning,
-                                  "warning" => warning_string)
+        "warning_level" => :warning,
+        "warning"       => warning_string
+      )
       proposal = subject.make_proposal({})
       expect(proposal["warning"]).to include(warning_string)
       expect(proposal["warning_level"]).to eq(:warning)

--- a/test/migration_proposal_client_test.rb
+++ b/test/migration_proposal_client_test.rb
@@ -47,6 +47,10 @@ describe Migration::ProposalClient do
 
   describe "#make_proposal" do
     let(:msg) { "Product <b>Foo</b> will be installed" }
+    let(:products) { load_yaml_data("sles12_migration_products.yml").map do |p|
+      Y2Packager::Resolvable.new(p)
+    end
+    }
 
     before do
       expect(Yast::Pkg).to receive(:PkgSolve)
@@ -55,13 +59,14 @@ describe Migration::ProposalClient do
       expect(Yast::SpaceCalculation).to receive(:GetPartitionInfo)
       expect(Yast::Packages).to receive(:product_update_summary)
         .and_return([msg])
-      expect(Yast::Pkg).to receive(:ResolvableProperties).with("", :product, "")
-        .and_return(load_yaml_data("sles12_migration_products.yml"))
+      expect(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
+        .and_return(products)
       expect(Yast::Pkg).to receive(:SourceGeneralData).with(0)
         .and_return("name" => "Repo")
     end
 
     it "returns a map with proposal details" do
+      expect(Yast::Packages).to receive(:product_update_warning).and_return({})
       proposal = subject.make_proposal({})
 
       expect(proposal).to include("help", "preformatted_proposal")
@@ -69,9 +74,12 @@ describe Migration::ProposalClient do
     end
 
     it "returns a warning when an obsoleted repository is present" do
+      warning_string = "warning string"
+      expect(Yast::Packages).to receive(:product_update_warning).and_return(
+                                  "warning_level" => :warning,
+                                  "warning" => warning_string)
       proposal = subject.make_proposal({})
-      expect(proposal["warning"]).to include("Repository <b>Repo</b> is obsolete " \
-          "and should be excluded from migration")
+      expect(proposal["warning"]).to include(warning_string)
       expect(proposal["warning_level"]).to eq(:warning)
     end
   end

--- a/test/repository_checker_test.rb
+++ b/test/repository_checker_test.rb
@@ -24,7 +24,11 @@ require "migration/repository_checker"
 
 describe Migration::RepositoryChecker do
   subject do
-    Migration::RepositoryChecker.new(load_yaml_data("sles12_migration_products.yml"))
+    Y2Packager::Resolvable.new
+    products = load_yaml_data("sles12_migration_products.yml").map do |p|
+      Y2Packager::Resolvable.new(p)
+    end
+    Migration::RepositoryChecker.new(products)
   end
 
   describe "#obsolete_product_repos" do

--- a/test/repository_checker_test.rb
+++ b/test/repository_checker_test.rb
@@ -24,7 +24,6 @@ require "migration/repository_checker"
 
 describe Migration::RepositoryChecker do
   subject do
-    Y2Packager::Resolvable.new
     products = load_yaml_data("sles12_migration_products.yml").map do |p|
       Y2Packager::Resolvable.new(p)
     end


### PR DESCRIPTION
Replacing old Pkg.ResolvableProperties()and Pkg.ResolvabeDependencies() calls by Y2Packager::Resolvable.any? and Y2Packager::Resolvable.find in order to save memory.