### PR TITLE
[SLE-15-SP2] Show license in online migration (bsc#1185808)

### DIFF
--- a/package/yast2-migration.changes
+++ b/package/yast2-migration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May 12 08:53:10 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Show the new base product license in online migration
+  (bsc#1185808)
+- 4.2.5
+
+-------------------------------------------------------------------
 Tue Nov 19 12:00:26 CET 2019 - schubi@suse.de
 
 - Using Y2Packager::Resolvable.any? and Y2Packager::Resolvable.find

--- a/package/yast2-migration.spec
+++ b/package/yast2-migration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-migration
-Version:        4.2.4
+Version:        4.2.5
 Release:        0
 Summary:        YaST2 - Online migration
 Group:          System/YaST

--- a/src/lib/migration/main_workflow.rb
+++ b/src/lib/migration/main_workflow.rb
@@ -103,7 +103,11 @@ module Migration
       "repositories"            => {
         abort:    :abort,
         rollback: "rollback",
-        next:     "proposals"
+        next:     "license"
+      },
+      "license"                 => {
+        abort: "rollback",
+        next:  "proposals"
       },
       "proposals"               => {
         abort: "rollback",
@@ -146,6 +150,7 @@ module Migration
         "perform_migration"       => ->() { perform_migration },
         "proposals"               => ->() { proposals },
         "repositories"            => ->() { repositories },
+        "license"                 => ->() { license },
         "restart_after_migration" => ->() { restart_yast(:restart_after_migration) },
         # note: the steps after the YaST restart use the new code from
         # the updated (migrated) yast2-migration package!!
@@ -196,6 +201,11 @@ module Migration
     def repositories
       prepare_repos
       Yast::WFM.CallFunction("migration_repos", [{ "enable_back" => false }])
+    end
+
+    # display license for the new base product
+    def license
+      Yast::WFM.CallFunction("inst_product_upgrade_license", [{ "enable_back" => false }])
     end
 
     def proposals

--- a/test/main_workflow_test.rb
+++ b/test/main_workflow_test.rb
@@ -35,6 +35,7 @@ describe Migration::MainWorkflow do
 
     before do
       mock_client(["migration_repos", [{ "enable_back" => false }]], :next)
+      mock_client(["inst_product_upgrade_license", [{ "enable_back" => false }]], :next)
       mock_client(["migration_proposals", [{ "hide_export" => true }]], :next)
       mock_client("inst_prepareprogress", :next)
       mock_client("inst_kickoff", :next)


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1185808
- The product license was not displayed during online migration.
- It is displayed during offline migration and also in online migration via zypper, let's unify it.

### Testing

- Tested manually, see this screencast:

![online_migration_license](https://user-images.githubusercontent.com/907998/117946713-d6873a80-b30f-11eb-86be-bdcf8063d55c.gif)


### Notes
- The `"enable_back" => false` parameter is actually ignored by the `inst_product_upgrade_license` client. We might fix it later, it is in a different package...