### PR TITLE
[SLE-15-GA] Show license in online migration (bsc#1185808)

### DIFF
--- a/package/yast2-migration.changes
+++ b/package/yast2-migration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun 22 11:13:07 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Show the new base product license in online migration
+  (bsc#1185808)
+- 4.0.1
+
+-------------------------------------------------------------------
 Thu Dec  7 15:23:31 UTC 2017 - igonzalezsosa@suse.com
 
 - Bump version to follow the new versioning guidelines

--- a/package/yast2-migration.spec
+++ b/package/yast2-migration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-migration
-Version:        4.0.0
+Version:        4.0.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/migration/main_workflow.rb
+++ b/src/lib/migration/main_workflow.rb
@@ -93,7 +93,11 @@ module Migration
       "repositories"            => {
         abort:    :abort,
         rollback: "rollback",
-        next:     "proposals"
+        next:     "license"
+      },
+      "license"                 => {
+        abort: "rollback",
+        next:  "proposals"
       },
       "proposals"               => {
         abort: "rollback",
@@ -136,6 +140,7 @@ module Migration
         "perform_migration"       => ->() { perform_migration },
         "proposals"               => ->() { proposals },
         "repositories"            => ->() { repositories },
+        "license"                 => ->() { license },
         "restart_after_migration" => ->() { restart_yast(:restart_after_migration) },
         # note: the steps after the YaST restart use the new code from
         # the updated (migrated) yast2-migration package!!
@@ -185,6 +190,11 @@ module Migration
 
     def repositories
       Yast::WFM.CallFunction("migration_repos", [{ "enable_back" => false }])
+    end
+
+    # display license for the new base product
+    def license
+      Yast::WFM.CallFunction("inst_product_upgrade_license", [{ "enable_back" => false }])
     end
 
     def proposals

--- a/test/main_workflow_test.rb
+++ b/test/main_workflow_test.rb
@@ -35,6 +35,7 @@ describe Migration::MainWorkflow do
 
     before do
       mock_client(["migration_repos", [{ "enable_back" => false }]], :next)
+      mock_client(["inst_product_upgrade_license", [{ "enable_back" => false }]], :next)
       mock_client(["migration_proposals", [{ "hide_export" => true }]], :next)
       mock_client("inst_prepareprogress", :next)
       mock_client("inst_kickoff", :next)


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1185808
- Just backporting PR #57 to GA
- See PR https://github.com/yast/yast-migration/pull/57 for more details